### PR TITLE
[fixed] issue 39: paperclip storage for each env

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -6,9 +6,7 @@ class ServiceOrder < ActiveRecord::Base
   validates :email, email: true
   validates :domain, uniqueness: true
 
-  has_attached_file :header_image, :styles => { :medium => "1200x800>" },
-    :storage => :dropbox,
-    :dropbox_credentials => Rails.root.join("config/dropbox.yml")
+  has_attached_file :header_image, { :styles => { :medium => "1200x800>" } }.merge(PaperclipStorageOption.options)
   validates_attachment_content_type :header_image, :content_type => /\Aimage\/.*\Z/
 
   def short_his_name

--- a/config/initializers/paperclip_storage_option.rb
+++ b/config/initializers/paperclip_storage_option.rb
@@ -1,0 +1,22 @@
+module PaperclipStorageOption
+  module ClassMethods
+    def options
+      Rails.env.production? ? production_options : default_options
+    end
+
+    private
+
+    def production_options
+      {
+        storage: :dropbox,
+        dropbox_credentials: Rails.root.join("config/dropbox.yml")
+      }
+    end
+
+    def default_options
+      {}
+    end
+  end
+
+  extend ClassMethods
+end


### PR DESCRIPTION
Specify each storage for each env. Only use dropbox for production env.