### PR TITLE
Validate domain name

### DIFF
--- a/app/assets/javascripts/service_orders.coffee
+++ b/app/assets/javascripts/service_orders.coffee
@@ -35,6 +35,14 @@ ready = ->
       "service_order[domain]":
         pattern: /^([a-z0-9]){3,20}$/
         required: true
+        remote:
+          url: "/service_orders/valid"
+          type: "post"
+          data:
+            service_order:
+              domain: ->
+                $("#service_order_domain").val()
+
     errorPlacement:
       (error, element) ->
         errorDiv = $('<span>', { class: 'error-icon fa fa-exclamation-triangle' })
@@ -50,6 +58,10 @@ ready = ->
     success:
       (label, element) ->
         $(element).parent().children().remove('.error-icon')
+
+    messages:
+      "service_order[domain]":
+        remote: "Domain is existed. Please choose another one."
   )
 
 $(document).ready(ready)

--- a/app/controllers/service_orders_controller.rb
+++ b/app/controllers/service_orders_controller.rb
@@ -22,8 +22,8 @@ class ServiceOrdersController < ApplicationController
     end
   end
 
-  def domain_validate
-    ServiceOrder.valid(domain: domain)
+  def valid
+    render text: ServiceOrder.valid(service_order_params)
   end
 
   private

--- a/app/controllers/service_orders_controller.rb
+++ b/app/controllers/service_orders_controller.rb
@@ -22,6 +22,10 @@ class ServiceOrdersController < ApplicationController
     end
   end
 
+  def domain_validate
+    ServiceOrder.valid(domain: domain)
+  end
+
   private
     def set_service_order
       @service_order = ServiceOrder.find(params[:id])

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -21,6 +21,11 @@ class ServiceOrder < ActiveRecord::Base
   def self.valid(attrs)
     object = new(attrs)
     object.valid?
-    !object.errors.messages.include?(attrs.keys.first.to_sym)
+
+    attrs.keys.map(&:to_sym).each do |key|
+      return false if object.errors.messages.include?(key)
+    end
+
+    true
   end
 end

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -17,4 +17,10 @@ class ServiceOrder < ActiveRecord::Base
   def short_her_name
     her_name.split(" ").first
   end
+
+  def self.valid(attrs)
+    object = new(attrs)
+    object.valid?
+    !object.errors.messages.include?(attrs.keys.first)
+  end
 end

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -21,6 +21,6 @@ class ServiceOrder < ActiveRecord::Base
   def self.valid(attrs)
     object = new(attrs)
     object.valid?
-    !object.errors.messages.include?(attrs.keys.first)
+    !object.errors.messages.include?(attrs.keys.first.to_sym)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get 'errors/show'
 
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
+
   namespace :admin do
     resources :service_orders, only: [:index, :edit, :update, :destroy]
     root to: 'service_orders#index'
@@ -11,7 +12,9 @@ Rails.application.routes.draw do
   devise_for :admin_users
   get 'homes/index'
 
-  resources :service_orders, only: [:new, :create, :show]
+  resources :service_orders, only: [:new, :create, :show, :valid] do
+    post 'valid', on: :collection
+  end
 
   get '/', to: 'service_orders#show', constraints: { subdomain: /.+\.4ever/ }
 

--- a/spec/controllers/service_orders_controller_spec.rb
+++ b/spec/controllers/service_orders_controller_spec.rb
@@ -58,4 +58,23 @@ RSpec.describe ServiceOrdersController, :type => :controller do
     end
   end
 
+  describe "POST valid" do
+    context "returns valid text" do
+      let(:params) { { service_order: { domain: "a-good-domain" } } }
+
+      it "renders text" do
+        post :valid, params
+        expect(response.body).to eq("true")
+      end
+    end
+
+    context "returns invalid text" do
+      let(:params) { { service_order: { domain: "d" } } }
+
+      it "renders text" do
+        post :valid, params
+        expect(response.body).to eq("false")
+      end
+    end
+  end
 end

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -81,4 +81,40 @@ describe ServiceOrder do
       end
     end
   end
+
+  describe ".valid" do
+    context "validates a valid domain name" do
+      let(:domain) { 'gooddomain' }
+      let(:domain2) { 'gooddomain-abc' }
+
+      it "returns true" do
+        expect(ServiceOrder.valid(domain: domain)).to be true
+        expect(ServiceOrder.valid(domain: domain2)).to be true
+      end
+    end
+
+    context "validates an invalid domain name" do
+      let(:domain) { 'go##domain' }
+
+      context "format error" do
+        it "returns false" do
+          expect(ServiceOrder.valid(domain: domain)).to be false
+        end
+      end
+
+      context "domain existed" do
+        before do
+          create(:service_order, domain: "exist")
+        end
+
+        it "returns true" do
+          expect(ServiceOrder.valid(domain: "not-exist")).to be true
+        end
+
+        it "returns false" do
+          expect(ServiceOrder.valid(domain: "exist")).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -135,7 +135,6 @@ describe ServiceOrder do
 
         before { create:service_order, domain: 'gooddomain' }
 
-
         it "returns false" do
           expect(ServiceOrder.valid(invalid_fields1)).to be false
         end

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -83,36 +83,65 @@ describe ServiceOrder do
   end
 
   describe ".valid" do
-    context "validates a valid domain name" do
-      let(:domain) { 'gooddomain' }
-      let(:domain2) { 'gooddomain-abc' }
+    context "validates 1 fields" do
+      context "validates a valid domain name" do
+        let(:domain) { 'gooddomain' }
+        let(:domain2) { 'gooddomain-abc' }
 
-      it "returns true" do
-        expect(ServiceOrder.valid(domain: domain)).to be true
-        expect(ServiceOrder.valid(domain: domain2)).to be true
+        it "returns true" do
+          expect(ServiceOrder.valid(domain: domain)).to be true
+          expect(ServiceOrder.valid(domain: domain2)).to be true
+        end
+      end
+
+      context "validates an invalid domain name" do
+        let(:domain) { 'go##domain' }
+
+        context "format error" do
+          it "returns false" do
+            expect(ServiceOrder.valid(domain: domain)).to be false
+          end
+        end
+
+        context "domain existed" do
+          before do
+            create(:service_order, domain: "exist")
+          end
+
+          it "returns true" do
+            expect(ServiceOrder.valid(domain: "not-exist")).to be true
+          end
+
+          it "returns false" do
+            expect(ServiceOrder.valid(domain: "exist")).to be false
+          end
+        end
       end
     end
 
-    context "validates an invalid domain name" do
-      let(:domain) { 'go##domain' }
+    context "validates more fields" do
+      context "validates a valid domain name and email" do
+        let(:valid_fields) { { domain: 'gooddomain', email: 'email@gmail.com' } }
+        subject { ServiceOrder.valid(valid_fields) }
 
-      context "format error" do
-        it "returns false" do
-          expect(ServiceOrder.valid(domain: domain)).to be false
+        it "returns true" do
+          expect(subject).to be true
         end
       end
 
-      context "domain existed" do
-        before do
-          create(:service_order, domain: "exist")
-        end
+      context "validates fail for an existed domain name" do
+        let(:invalid_fields1) { { domain: 'gooddomain', email: 'email@gmail.com' } }
+        let(:invalid_fields2) { { domain: 'gooddomain2', email: 'invalid' } }
 
-        it "returns true" do
-          expect(ServiceOrder.valid(domain: "not-exist")).to be true
+        before { create:service_order, domain: 'gooddomain' }
+
+
+        it "returns false" do
+          expect(ServiceOrder.valid(invalid_fields1)).to be false
         end
 
         it "returns false" do
-          expect(ServiceOrder.valid(domain: "exist")).to be false
+          expect(ServiceOrder.valid(invalid_fields2)).to be false
         end
       end
     end


### PR DESCRIPTION
Add remote validation action for ``service_orders_controller``

Allow call ``POST /service_orders/valid`` with params format ``{ service_orders: {key: hash} }``